### PR TITLE
Updated pippi to be compatible with Python 3

### DIFF
--- a/Readme
+++ b/Readme
@@ -24,7 +24,7 @@ Installation
 Pippi requires almost no installation.
 
 1. Make sure you have the following already installed:
-   * Python v2.7 or later
+   * Either Python v2.7 or later or Python v3
    * NumPy and SciPy libraries for python (NumPy v0.9.0 or
      greater is required for full functionality)
    * ctioga2 v0.8 or later

--- a/pippi
+++ b/pippi
@@ -15,6 +15,7 @@
 # Originally developed: March 2012
 #############################################################
 
+from __future__ import print_function
 from pippi_probe  import *
 from pippi_merge  import *
 from pippi_pare   import *
@@ -37,41 +38,41 @@ def main(arguments):
       #Check if pippi has been invoked with one of the five known specific commands
       command = commandLineOptions[arguments[1]]
       if not command in [merge, pare]:
-        print
-        print 'Beginning pippi '+arguments[1]+' operation...'
+        print()
+        print('Beginning pippi '+arguments[1]+' operation...')
       try:
         command(arguments[2:])
       except BaseException as err:
-        print
-        print 'Running pippi failed in '+command.__name__+' operation, due to error:'
-        print err
-        print
+        print()
+        print('Running pippi failed in '+command.__name__+' operation, due to error:')
+        print(err)
+        print()
         sys.exit()
       if not command in [merge, pare]:
-        print
-        print 'Completed sucessfully.'
-        print
+        print()
+        print('Completed sucessfully.')
+        print()
     except KeyError:
       #Otherise check if it has been invoked with just a filename
       if os.path.isfile(arguments[1]):
-        print
-        print 'Beginning pippi parse-to-plot operation...'
+        print()
+        print('Beginning pippi parse-to-plot operation...')
         for command in [parse, script, plot]:
           try:
             command(arguments[1:])
           except BaseException as err:
-            print
-            print 'Running pippi failed in '+command.__name__+' operation.'
-            print err
-            print
+            print()
+            print('Running pippi failed in '+command.__name__+' operation.')
+            print(err)
+            print()
             sys.exit()
-        print
-        print 'Completed sucessfully.'
-        print
+        print()
+        print('Completed sucessfully.')
+        print()
       else:
         #Otherwise crack it and tell the user to get their shit in order
-        print
-        print 'Can\'t find file '+arguments[1]
+        print()
+        print('Can\'t find file '+arguments[1])
         usage()
 
   sys.exit()

--- a/pippi_merge.py
+++ b/pippi_merge.py
@@ -8,6 +8,7 @@
 # Originally developed: March 2012
 #############################################################
 
+from __future__ import print_function
 from pippi_utils import *
 
 def merge(filenames):
@@ -30,11 +31,11 @@ def merge(filenames):
     import h5py
     f = h5py.File(filenames[0],'r')
     h5merge = True
-    print
-    print "Files identified as hdf5.  Interpreting final argument as output filename."
-    print
-    print "Concatenating common datasets and outputting to {0}...".format(filenames[-1])
-    print
+    print()
+    print("Files identified as hdf5.  Interpreting final argument as output filename.")
+    print()
+    print("Concatenating common datasets and outputting to {0}...".format(filenames[-1]))
+    print()
   except:
     h5merge = False
 
@@ -49,19 +50,19 @@ def merge(filenames):
     try:
       fout = h5py.File(filenames[-1],'w-')
     except:
-      print "Could not create output file {0}!".format(filenames[-1])
-      print "Please make sure it does not exist already."
-      print
+      print("Could not create output file {0}!".format(filenames[-1]))
+      print("Please make sure it does not exist already.")
+      print()
       return
 
-    print "  Determining common datasets..."
+    print("  Determining common datasets...")
     for fname in filenames[0:-1]:
-      print "    Opening: {0}".format(fname)
+      print("    Opening: {0}".format(fname))
       try:
         f = h5py.File(fname,'r')
       except:
-        print "Could not open file {0}!".format(fname)
-        print
+        print("Could not open file {0}!".format(fname))
+        print()
         return
       files[fname] = f
       datasets = {}
@@ -77,13 +78,13 @@ def merge(filenames):
       datashape = dataset_collection[0][x].shape
       if all(f[x].dtype == datatype and f[x].shape[1:] == datashape[1:] for f in dataset_collection):
         common_datasets.add(x)
-    print
-    print "  Common datasets: "
-    for x in common_datasets: print "    {0}".format(x)
-    print
+    print()
+    print("  Common datasets: ")
+    for x in common_datasets: print("    {0}".format(x))
+    print()
 
     #Find the length of each dataset and create it (empty) in the new file
-    print "  Creating empty datasets of required lengths in {0}...".format(filenames[-1])
+    print("  Creating empty datasets of required lengths in {0}...".format(filenames[-1]))
     out_dsets = {}
     for ds in common_datasets:
       length = 0
@@ -91,21 +92,21 @@ def merge(filenames):
       datatype = dataset_collection[0][ds].dtype
       datashape = (length,) + dataset_collection[0][ds].shape[1:]
       out_dsets[ds] = fout.create_dataset(ds, datashape, dtype=datatype)
-    print
+    print()
 
     #Copy the data over to the new file
-    print "  Adding data to empty datasets in {0}...".format(filenames[-1])
+    print("  Adding data to empty datasets in {0}...".format(filenames[-1]))
     for ds in common_datasets:
-      print "    Populating {0}".format(ds)
+      print("    Populating {0}".format(ds))
       index_low = 0
       for f in dataset_collection:
         index_high = index_low + f[ds].len()
         out_dsets[ds][index_low:index_high,...] = f[ds][...]
         index_low = index_high
 
-    print
-    print "Done."
-    print
+    print()
+    print("Done.")
+    print()
 
 
   else:    # We are doing an ASCII merge
@@ -137,7 +138,7 @@ def merge(filenames):
             #Crash if a later chain or line has a different number of columns to the first one
             sys.exit('Error: chains do not match (number of columns differ).  Quitting...')
           #Output the current line to stdout and get the next one
-          print line.rstrip('\n')
+          print(line.rstrip('\n'))
           #Read the next line
           line = infile.readline()
           #Work out the number of columns in the next line
@@ -150,6 +151,6 @@ def merge(filenames):
 
 def get_datasets(g,datasets):
   import h5py
-  for name, item in g.iteritems():
+  for name, item in g.items():
     if isinstance(item,h5py.Group): get_datasets(item,datasets)
     if isinstance(item,h5py.Dataset): datasets[item.name] = item

--- a/pippi_pare.py
+++ b/pippi_pare.py
@@ -8,6 +8,7 @@
 # Originally developed: March 2012
 #############################################################
 
+from __future__ import print_function
 from pippi_utils import *
 from pippi_read import *
 from importlib import import_module
@@ -45,6 +46,6 @@ def pare(argstring):
 
   # Pump it through the user-supplied function, printing each new point to stdout
   for i in range(chainArray.shape[0]):
-    print '\t'.join([str(x) for x in pareFunc(chainArray[i,:])])
+    print('\t'.join([str(x) for x in pareFunc(chainArray[i,:])]))
 
 

--- a/pippi_parse.py
+++ b/pippi_parse.py
@@ -8,6 +8,7 @@
 # Originally developed: March 2012
 #############################################################
 
+from __future__ import print_function
 import subprocess
 from pippi_utils import *
 from pippi_read import *
@@ -77,13 +78,13 @@ def parse(filename):
 
   #Check that flags match up for profile likelihood
   if all(x not in labels.value for x in permittedLikes) and doProfile.value:
-    print '  Warning: no likelihood in chain labels.\n  Skipping profile likelihood...'
+    print('  Warning: no likelihood in chain labels.\n  Skipping profile likelihood...')
     doProfile.value = False
 
   #Work out whether to do posterior mean and check that flags match up for posterior pdf
   doPosteriorMean = any(x in labels.value for x in permittedMults)
   if doPosterior.value and not doPosteriorMean:
-    print '  Warning: do_posterior_pdf = T but no multiplicity in chain labels.\n  Skipping posterior PDF...'
+    print('  Warning: do_posterior_pdf = T but no multiplicity in chain labels.\n  Skipping posterior PDF...')
     doPosterior.value = False
 
   #Check that flags match up for evidence
@@ -92,10 +93,10 @@ def parse(filename):
       if all(x not in labels.value for x in permittedLikes) or \
          all(x not in labels.value for x in permittedMults) or \
          all(x not in labels.value for x in permittedPriors):
-        print '  The evidence cannot be calculated without multiplicity, prior and likelihood.\n  Skipping evidence...'
+        print('  The evidence cannot be calculated without multiplicity, prior and likelihood.\n  Skipping evidence...')
         doEvidence.value = False
     else:
-      print '  The evidence can only be calculated from an MCMC chain.\n  Skipping evidence...'
+      print('  The evidence can only be calculated from an MCMC chain.\n  Skipping evidence...')
       doEvidence.value = False
 
   #Check that flags and match up for quantities selected for plotting
@@ -147,8 +148,8 @@ def parse(filename):
       # Parse comparison chain
       doParse(mainArray,lookupKey,outputBaseFilename,setOfRequestedColumns,hdf5_names,dataRanges,all_best_fit_data,nBins,iBins,alt_best_fit)
     else:
-      print '    Chain '+secChain.value+' has less columns than required to do all requested plots.'
-      print '    Skipping parsing of this chain...'
+      print('    Chain '+secChain.value+' has less columns than required to do all requested plots.')
+      print('    Skipping parsing of this chain...')
 
 
 def doParse(dataArray,lk,outputBaseFilename,setOfRequestedColumns,column_names,dataRanges,all_best_fit_data,nBins,iBins,alt_best_fit):
@@ -182,7 +183,7 @@ def doParse(dataArray,lk,outputBaseFilename,setOfRequestedColumns,column_names,d
 def standardise(dataArray,lk):
   global firstLikeKey
   # Standardise likelihood, prior and multiplicity labels, rescale likelihood if necessary,
-  for key, entry in labels.value.copy().iteritems():
+  for key, entry in labels.value.copy().items():
     if any(key == mult for mult in permittedMults):
       labels.value[refMult] = labels.value[key]
       if key != refMult: del labels.value[key]
@@ -203,21 +204,21 @@ def standardise(dataArray,lk):
     #if any(entry == obs for obs in permittedObs): labels.value[key] = refObs
   # Rescale columns if requested
   if rescalings.value is not None:
-    for key, entry in rescalings.value.iteritems(): dataArray[:,lk[key]] *= entry
+    for key, entry in rescalings.value.items(): dataArray[:,lk[key]] *= entry
   # Convert columns to log if requested
   if logPlots.value is not None:
     for column in logPlots.value:
       if column in lk:
         if any(dataArray[:,lk[column]] <= 0.0):
-          print "Error: column {0} requested for log plotting has non-positive values!".format(column)
+          print("Error: column {0} requested for log plotting has non-positive values!".format(column))
           bad_indices = np.where(dataArray[:,lk[column]] <= 0.0)[0]
-          print "Here is the first point with bad values, for example: "
+          print("Here is the first point with bad values, for example: ")
           for i,val in enumerate(dataArray[bad_indices[0],:]):
             index = i
             for x in lk:
               if lk[x] == i:
                 index = x
-            print "  col {0}: {1}".format(index,val)
+            print("  col {0}: {1}".format(index,val))
           sys.exit('\nPlease fix log settings (or your data) and rerun pippi.')
         dataArray[:,lk[column]] = np.log10(dataArray[:,lk[column]])
 
@@ -234,7 +235,7 @@ def getBestFit(dataArray,lk,outputBaseFilename,column_names,all_best_fit_data,al
   bestFitIndex = dataArray[:,lk[labels.value[refLike]]].argmin()
   bestFit = dataArray[bestFitIndex,lk[labels.value[refLike]]]
   worstFit = dataArray[:,lk[labels.value[refLike]]].max()
-  print '    Best fit -lnlike: ',bestFit
+  print('    Best fit -lnlike: ',bestFit)
   outfile = smart_open(outputBaseFilename+'.best','w')
   outfile.write('# This best-fit/posterior mean file created by pippi '
            +pippiVersion+' on '+datetime.datetime.now().strftime('%c')+'\n')
@@ -267,7 +268,7 @@ def getBestFit(dataArray,lk,outputBaseFilename,column_names,all_best_fit_data,al
       outfile2.write('# This best-fit file created in GAMBIT yaml format by pippi '
                      +pippiVersion+' on '+datetime.datetime.now().strftime('%c')+'\n')
       outfile2.write('# Best-fit log-likelihood: '+str(-bestFit)+'\n\n')
-      for model, parameters in parameter_sets.iteritems():
+      for model, parameters in parameter_sets.items():
         outfile2.write('    ' + model + ':\n')
         for parval in parameters: outfile2.write('  ' + parval + '\n')
       outfile2.close
@@ -275,7 +276,7 @@ def getBestFit(dataArray,lk,outputBaseFilename,column_names,all_best_fit_data,al
   if alt_best_fit.value is not None:
     halt = (min_contour is not None) and (bestFit+alt_best_fit.value > min_contour)
     bestFit = -alt_best_fit.value
-    print '    Best fit -lnlike to be used to define profile likelihood ratio: ',bestFit
+    print('    Best fit -lnlike to be used to define profile likelihood ratio: ',bestFit)
     if halt: sys.exit('\n  The highest CL likelihood likelihood contour you have requested contains no samples! No more pippi for you.\n')
   return [bestFit,worstFit,bestFitIndex]
 
@@ -309,7 +310,7 @@ def getEvidence(dataArray,lk,bestFit,totalMult,outputBaseFilename):
                           np.exp(bestFit-dataArray[:,lk[labels.value[refLike]]]))) \
                           - bestFit - np.log(totalMult)
       lnZError = np.log(1.0 - pow(totalMult,-0.5))
-      print '    ln(evidence): ',lnZ,'+/-',lnZError
+      print('    ln(evidence): ',lnZ,'+/-',lnZError)
     else:
       sys.exit('Error: evidence calculation only possible for MCMC (should never get here).')
     outfile = smart_open(outputBaseFilename+'.lnZ','w')
@@ -340,7 +341,7 @@ def saveLookupKeys(lk,outputBaseFilename):
   outfile = smart_open(outputBaseFilename+'_savedkeys.pip','a')
   outfile.write('lookup_keys =')
   if type(lk) == dict:
-    for key, value in lk.iteritems(): outfile.write(' '+str(key)+':'+str(value))
+    for key, value in lk.items(): outfile.write(' '+str(key)+':'+str(value))
   else:
     for i in lk: outfile.write(' '+str(i)+':'+str(i))
   outfile.write('\n')
@@ -363,7 +364,7 @@ def oneDsampler(dataArray,lk,bestFit,worstFit,outputBaseFilename,dataRanges,nAll
 
   for plot in oneDplots.value:
 
-    print '    Parsing data for 1D plots of quantity ',plot
+    print('    Parsing data for 1D plots of quantity ',plot)
 
     nBins = nAllBins[plot]
     resolution = rAllBins[plot]
@@ -497,7 +498,7 @@ def twoDsampler(dataArray,lk,bestFit,worstFit,outputBaseFilename,dataRanges,nAll
 
   for plot in twoDplots.value:
 
-    print '    Parsing data for 2D plots of quantities ',plot
+    print('    Parsing data for 2D plots of quantities ',plot)
 
     nBins = [nAllBins[plot[j]] for j in range(2)]
     resolution = [rAllBins[plot[j]] for j in range(2)]

--- a/pippi_plot.py
+++ b/pippi_plot.py
@@ -8,6 +8,7 @@
 # Originally developed: March 2012
 #############################################################
 
+from __future__ import print_function
 import subprocess
 from pippi_utils import *
 from pippi_read import *
@@ -27,7 +28,7 @@ keys = keys+[parsedir,scriptdir,outdir,prepend,append]
 
 def plot(filename):
 
-  print
+  print()
 
   # Parse pip file
   getIniData(filename,keys)
@@ -60,7 +61,7 @@ def plot(filename):
 
   #Work out whether to do posteriors check that flags match up for posterior pdf
   if doPosterior.value and not any(x in labels.value for x in permittedMults):
-    print '  Warning: do_posterior_pdf = T but no multiplicity in chain labels.\n  Skipping posterior PDF...'
+    print('  Warning: do_posterior_pdf = T but no multiplicity in chain labels.\n  Skipping posterior PDF...')
     doPosterior.value = False
 
   # Set defaults for prepend and append string
@@ -72,7 +73,7 @@ def plot(filename):
   if oneDplots.value is not None:
     # Work through 1D plotting scripts
     for plot in oneDplots.value:
-      print '    Running plotting scripts for 1D plots of quantity ',plot
+      print('    Running plotting scripts for 1D plots of quantity ',plot)
       # Set up filenames
       currentBase = baseFilename+'_'+str(plot)
       # Make profile likelihood plots
@@ -95,7 +96,7 @@ def plot(filename):
   if twoDplots.value is not None:
     # Loop over requested plots
     for plot in twoDplots.value:
-      print '    Running plotting scripts for 2D plots of quantity ',plot
+      print('    Running plotting scripts for 2D plots of quantity ',plot)
       # Set up filenames
       currentBase = baseFilename+'_'+'_'.join([str(x) for x in plot])
       # Make profile likelihood plots

--- a/pippi_read.py
+++ b/pippi_read.py
@@ -9,6 +9,7 @@
 #           Pat Scott, 2016
 #############################################################
 
+from __future__ import print_function
 import datetime
 import sys
 from pippi_utils import *
@@ -44,7 +45,7 @@ def getIniData(filename,keys,savekeys=None,savedir=None):
 
   #Find relevant bits in pipfile
   for i,key in enumerate(keys):
-    lines = filter(key.seek,parse_options)
+    lines = list(filter(key.seek,parse_options))
     if (len(lines) == 0):
       sys.exit('Error: field '+key.pipFileKey+' required for requested operation not found in '+filename+'.  Quitting...\n')
     if (len(lines) > 1):
@@ -57,7 +58,7 @@ def getIniData(filename,keys,savekeys=None,savedir=None):
 
     # Make sure saving is actually possible
     if not mainChain in keys:
-      print '\n  Warning: saving of keys not possible because mainChain is undefined.\n  Skipping save...'
+      print('\n  Warning: saving of keys not possible because mainChain is undefined.\n  Skipping save...')
       return
 
     # Open the file keys will be saved to
@@ -72,8 +73,8 @@ def getIniData(filename,keys,savekeys=None,savedir=None):
 
     # Parse the pip file again and save the requested keys
     for key in savekeys:
-      lines = filter(key.seek,parse_options)
-      # Save keys verbatim to the savedkeys pip file
+      lines = list(filter(key.seek,parse_options))
+	  # Save keys verbatim to the savedkeys pip file
       if savekeys is not None and key in savekeys: outfile.write(lines[0])
 
   # Clean up
@@ -109,11 +110,11 @@ def getChainData(filename, cut_all_invalid=None, requested_cols=None, assignment
       for index in assignments.value:
         if castable_to_int(index):
           if ncols+n_extra_cols not in assignments.value:
-            print 'ERROR: When working with ASCII chains and trying to assign function'
-            print 'results to datastreams, all functional datastreams must be assigned indices'
-            print 'in continuous ascending order starting from the index of the last'
-            print 'column in the ASCII file. In this case, that means you must start with'
-            print str(ncols)+' and go up by one for each subsequent functional stream.'
+            print('ERROR: When working with ASCII chains and trying to assign function')
+            print('results to datastreams, all functional datastreams must be assigned indices')
+            print('in continuous ascending order starting from the index of the last')
+            print('column in the ASCII file. In this case, that means you must start with')
+            print(str(ncols)+' and go up by one for each subsequent functional stream.')
             sys.exit("")
           if not is_functional_assignment(assignments.value[ncols+n_extra_cols]):
             sys.exit('ERROR: When working with ASCII chains, all entries in assign_to_pippi_datastream\nmust be functional assignments.')
@@ -131,9 +132,9 @@ def getChainData(filename, cut_all_invalid=None, requested_cols=None, assignment
     #Close the chainfile and indicate success
     chainfile.close
     if not silent:
-      print
-      print '  Read chain '+filename
-      print
+      print()
+      print('  Read chain '+filename)
+      print()
 
     #Turn the whole lot into a numpy array of doubles
     data = np.array(data, dtype=np.float64)
@@ -148,23 +149,23 @@ def getChainData(filename, cut_all_invalid=None, requested_cols=None, assignment
           # Read in any python preamble specified in the pip file.
           if preamble is not None: exec(preamble)
           exec('data[:,'+str(i)+'] = '+expression)
-        except KeyError, e:
-          print 'ERROR: Datastream '+str(e)+', which you have tried to define a function of'
-          print 'in assign_to_pippi_datastream, is not itself defined as a datastream.'
-          print 'This usually happens because it does not exist in the chain you are trying'
-          print 'to parse. Please fix assignment "'+assignments.value[i]+'".'
+        except KeyError as e:
+          print('ERROR: Datastream '+str(e)+', which you have tried to define a function of')
+          print('in assign_to_pippi_datastream, is not itself defined as a datastream.')
+          print('This usually happens because it does not exist in the chain you are trying')
+          print('to parse. Please fix assignment "'+assignments.value[i]+'".')
           sys.exit("")
         except:
-          print 'ERROR: something in one of the functions of datastreams you defined in '
-          print 'assign_to_pippi_datastream is buggy.  Please fix the expression: '
-          print assignments.value[i]
-          print 'Now raising the original error, so you can see the stacktrace for yourself...'
+          print('ERROR: something in one of the functions of datastreams you defined in ')
+          print('assign_to_pippi_datastream is buggy.  Please fix the expression: ')
+          print(assignments.value[i])
+          print('Now raising the original error, so you can see the stacktrace for yourself...')
           raise
 
     # Filter out points inside the requested data ranges
     cut = None
     if data_ranges is not None and data_ranges.value:
-      for key, value in data_ranges.value.iteritems():
+      for key, value in data_ranges.value.items():
         lowercut = value[0]
         uppercut = value[1]
         if log_plots.value is not None and key in log_plots.value:
@@ -179,24 +180,24 @@ def getChainData(filename, cut_all_invalid=None, requested_cols=None, assignment
           cut = np.logical_and(cut, np.logical_and(data[:,key] >= lowercut, data[:,key] <= uppercut))
       # Print the details of the cuts
       rescaling = 1.0
-      print "  Total samples: ", data.shape[0]
+      print("  Total samples: ", data.shape[0])
       if cut is not None:
         data = data[cut,:]
         sumcut = sum(cut)
-        print "  Total samples within requested data ranges: ", sumcut
+        print("  Total samples within requested data ranges: ", sumcut)
         if sumcut <= 0.0: sys.exit('Requested data cuts leave no remaining samples!')
         rescaling = 1.0*sumcut/len(cut)
-      print "  Fraction of samples within requested data ranges: %.4f"%(rescaling)
+      print("  Fraction of samples within requested data ranges: %.4f"%(rescaling))
 
   # HDF5 file
   else:
     filename, groupname = filename.split(":")
     if not silent:
-      print
-      print "  Reading HDF5 chain file"
-      print "    filename:", filename
-      print "    group:", groupname
-      print
+      print()
+      print("  Reading HDF5 chain file")
+      print("    filename:", filename)
+      print("    group:", groupname)
+      print()
 
     # Parse group entry
     groups = groupname.split('/')
@@ -220,7 +221,7 @@ def getChainData(filename, cut_all_invalid=None, requested_cols=None, assignment
           entries = entries[key]
         except KeyError:
           sys.exit("ERROR: requested group \""+key+"\" does not exist in hdf5 file.")
-    column_names = filter(lambda x: x[-8:] != "_isvalid", list(entries))
+    column_names = list(filter(lambda x: x[-8:] != "_isvalid", list(entries)))
 
     # Reorganize MPIrank, pointID and other requested entries for convenience.
     indices = []
@@ -257,7 +258,7 @@ def getChainData(filename, cut_all_invalid=None, requested_cols=None, assignment
     column_names = np.array(column_names)[all_indices]
     # Pick up all the datastreams with indices larger than the largest index in the hdf5 file
     if assignments.value is not None:
-      for index, assignment in assignments.value.iteritems():
+      for index, assignment in assignments.value.items():
         if castable_to_int(index) and index >= index_count:
           if is_functional_assignment(assignment):
             functional_assignment_indices.append(index)
@@ -275,19 +276,19 @@ def getChainData(filename, cut_all_invalid=None, requested_cols=None, assignment
     # Print probed contents and split
     if probe_only:
       for i, column_name in enumerate(column_names):
-        if column_name != '': print "   ", i, ":", column_name
-      print
+        if column_name != '': print("   ", i, ":", column_name)
+      print()
       quit()
 
     # Identify any likelihood or multiplicity indicated by the labels.
     if labels:
-      likelihood_index = [value for key, value in labels.value.iteritems() if key in permittedLikes]
-      if not likelihood_index: likelihood_index = [key for key, value in labels.value.iteritems() if value in permittedLikes]
+      likelihood_index = [value for key, value in labels.value.items() if key in permittedLikes]
+      if not likelihood_index: likelihood_index = [key for key, value in labels.value.items() if value in permittedLikes]
       if likelihood_index:
         likelihood_index = likelihood_index[0]
         if likelihood_index not in requested_cols: requested_cols.add(likelihood_index)
-      multiplicity_index = [value for key, value in labels.value.iteritems() if key in permittedMults]
-      if not multiplicity_index: multiplicity_index = [key for key, value in labels.value.iteritems() if value in permittedMults]
+      multiplicity_index = [value for key, value in labels.value.items() if key in permittedMults]
+      if not multiplicity_index: multiplicity_index = [key for key, value in labels.value.items() if value in permittedMults]
       if multiplicity_index:
         multiplicity_index = multiplicity_index[0]
         if multiplicity_index not in requested_cols: requested_cols.add(multiplicity_index)
@@ -312,25 +313,25 @@ def getChainData(filename, cut_all_invalid=None, requested_cols=None, assignment
         data_isvalid.append(np.array(entries[column_names[index]+"_isvalid"], dtype=np.float64))
       lookup_key[index] = index_count
       index_count += 1
-    non_functional_cols = [i for i, elem in enumerate(data) if data[i] is not 'functional']
+    non_functional_cols = [i for i, elem in enumerate(data) if data[i] != 'functional']
     if not non_functional_cols:
-      print "ERROR: At least one non-function assignment is needed in"
-      print "assign_to_pippi_datastream, or a multiplicity or likelihood"
-      print "identification in quantity_labels."
+      print("ERROR: At least one non-function assignment is needed in")
+      print("assign_to_pippi_datastream, or a multiplicity or likelihood")
+      print("identification in quantity_labels.")
       sys.exit("")
     # Print the raw number of samples in the hdf5 file
     total_samples = data[non_functional_cols[0]].size
-    print "  Total samples: ", total_samples
+    print("  Total samples: ", total_samples)
     # Fill in the functional columns with zeros.  Note that this uses more memory than doing it after validity
     # cuts, but should actually be faster (I think; haven't actually tested that). It makes the code simpler too.
     for i, elem in enumerate(data):
-      if elem is 'functional':
+      if elem == 'functional':
         data[i] = np.zeros(total_samples, dtype=np.float64)
       else:
         # Do some pruning to deal with cases where the some datasets have extra entries (although this arguably indicates a bug in the sampler)
         data[i] = elem[:total_samples]
     for i, elem in enumerate(data_isvalid):
-      if elem is 'functional':
+      if elem == 'functional':
         data_isvalid[i] = np.ones(total_samples, dtype=np.float64)
       else:
         # Do some pruning to deal with cases where the some datasets have extra entries (although this arguably indicates a bug in the sampler)
@@ -352,7 +353,7 @@ def getChainData(filename, cut_all_invalid=None, requested_cols=None, assignment
         # Based on the likelihood entry only
         if likelihood_index is not None:
           cut = (data_isvalid[lookup_key[likelihood_index]] == 1)
-    print "  Total valid samples: ", sum(cut)
+    print("  Total valid samples: ", sum(cut))
 
     # Fill in the derived quantities specified via functional assignments
     for i in sorted(functional_assignment_indices, key=int):
@@ -361,27 +362,27 @@ def getChainData(filename, cut_all_invalid=None, requested_cols=None, assignment
         # Read in any python preamble specified in the pip file.
         if preamble is not None: exec(preamble)
         exec('data[lookup_key['+str(i)+']] = '+expression)
-      except KeyError, e:
-        print 'ERROR: Datastream '+str(e)+', which you have tried to define a function of'
-        print 'in assign_to_pippi_datastream, is not itself defined as a datastream.'
-        print 'This usually happens because you have not requested it for plotting in'
-        print 'either oneD_plot_quantities or twoD_plot_quantities, so it has not been'
-        print 'extracted from the hdf5 file.  Please add it to one of these lists if you'
-        print 'really want to do the calculation "'+assignments.value[i]+'"'
+      except KeyError as e:
+        print('ERROR: Datastream '+str(e)+', which you have tried to define a function of')
+        print('in assign_to_pippi_datastream, is not itself defined as a datastream.')
+        print('This usually happens because you have not requested it for plotting in')
+        print('either oneD_plot_quantities or twoD_plot_quantities, so it has not been')
+        print('extracted from the hdf5 file.  Please add it to one of these lists if you')
+        print('really want to do the calculation "'+assignments.value[i]+'"')
         sys.exit("")
       except:
-        print 'ERROR: something in one of the functions of datastreams you defined in '
-        print 'assign_to_pippi_datastream is buggy.  Please fix the expression: '
-        print assignments.value[i]
-        print 'Now raising the original error, so you can see the stacktrace for yourself...'
+        print('ERROR: something in one of the functions of datastreams you defined in ')
+        print('assign_to_pippi_datastream is buggy.  Please fix the expression: ')
+        print(assignments.value[i])
+        print('Now raising the original error, so you can see the stacktrace for yourself...')
         raise
 
     # Filter out points inside the requested data ranges
     if data_ranges.value:
-      for key, value in data_ranges.value.iteritems():
+      for key, value in data_ranges.value.items():
         if key not in requested_cols:
-          print 'ERROR: '+str(key)+' mentioned in data_ranges does not'
-          print 'appear in requested_cols!  Please report this as a pippi bug.'
+          print('ERROR: '+str(key)+' mentioned in data_ranges does not')
+          print('appear in requested_cols!  Please report this as a pippi bug.')
         lowercut = value[0]
         uppercut = value[1]
         if log_plots.value is not None and key in log_plots.value:
@@ -401,7 +402,7 @@ def getChainData(filename, cut_all_invalid=None, requested_cols=None, assignment
       data = data[:,cut]
       data_isvalid = data_isvalid[:,cut]
       sumcut = sum(cut)
-      print "  Total valid samples within requested data ranges: ", sumcut
+      print("  Total valid samples within requested data ranges: ", sumcut)
       if sumcut == 0: sys.exit('  You cut out all your samples!  Pippi can\'t do much more from here.\n')
       rescaling = 1.0*sumcut/len(cut)
       # Find the full details of the best-fit point
@@ -409,7 +410,7 @@ def getChainData(filename, cut_all_invalid=None, requested_cols=None, assignment
         if likelihood_index in labels.value:
           findMin = labels.value[likelihood_index] in permittedLikes_samesign
         else:
-          findMin = [value for key, value in labels.value.iteritems() if key in permittedLikes_samesign]
+          findMin = [value for key, value in labels.value.items() if key in permittedLikes_samesign]
         if findMin:
           bestfit_any_index = np.ma.array(old_likelihood_column, mask=~cut).argmin()
           bestfit_index = data[lookup_key[likelihood_index]].argmin()
@@ -421,15 +422,15 @@ def getChainData(filename, cut_all_invalid=None, requested_cols=None, assignment
             all_best_fit_data.append(str(data[lookup_key[i]][bestfit_index]))
           else:
             if column_name != '': all_best_fit_data.append(str(entries[column_name][bestfit_any_index]))
-    print "  Fraction of samples deemed valid and within requested data ranges: %.4f"%(rescaling)
+    print("  Fraction of samples deemed valid and within requested data ranges: %.4f"%(rescaling))
 
     # Print list of contents for convenience
     if not silent:
-      for key, value in sorted(lookup_key.iteritems()):
-        print "   ",key, ":", column_names[key]
-        print "        mean: %.2e  min: %.2e  max %.2e"%(np.mean(data[value]), np.min(data[value]), np.max(data[value]))
-        print "        Fraction of valid points where this is invalid: %.4f"%(1.0-data_isvalid[value].mean())
-      print
+      for key, value in sorted(lookup_key.items()):
+        print("   ",key, ":", column_names[key])
+        print("        mean: %.2e  min: %.2e  max %.2e"%(np.mean(data[value]), np.min(data[value]), np.max(data[value])))
+        print("        Fraction of valid points where this is invalid: %.4f"%(1.0-data_isvalid[value].mean()))
+      print()
 
     # Flip 'em.
     data = np.array(data.T, dtype=np.float64)

--- a/pippi_script.py
+++ b/pippi_script.py
@@ -8,6 +8,7 @@
 # Originally developed: March 2012
 #############################################################
 
+from __future__ import print_function
 left_margin = 0.16
 right_margin = 0.03
 top_margin = 0.05
@@ -75,14 +76,14 @@ keyXVals = {'r':[0.74 + x*keyXSep for x in range(2)], 'c':[0.45 + x*keyXSep for 
 def script(filename):
   # input:  filename = the name of the pip file
 
-  print
+  print()
 
   # Parse pip file
   getIniData(filename,keys)
 
   # Make sure that comparison is turned off if comparison filename is missing
   if doComparison.value and secChain.value is None:
-    print '  Warning: comparison curves requested but no comparison file specified.\n  Skipping comparison...\n'
+    print('  Warning: comparison curves requested but no comparison file specified.\n  Skipping comparison...\n')
     doComparison.value = False
 
   # Work out where the parse output is located
@@ -141,7 +142,7 @@ def script(filename):
 
   #Work out whether to do posteriors and check that flags match up
   if doPosterior.value and not any(x in labels.value for x in permittedMults):
-    print '  Warning: do_posterior_pdf = T but no multiplicity in chain labels.\n  Skipping posterior PDF...'
+    print('  Warning: do_posterior_pdf = T but no multiplicity in chain labels.\n  Skipping posterior PDF...')
     doPosterior.value = False
 
   # set colour scheme if it is undefined
@@ -156,7 +157,7 @@ def script(filename):
     # Loop over requested plots
     for plot in oneDplots.value:
 
-      print '    Writing scripts for 1D plots of quantity ',plot
+      print('    Writing scripts for 1D plots of quantity ',plot)
 
       # Set up filenames
       currentBase = baseFilename+'_'+str(plot)
@@ -188,7 +189,7 @@ def script(filename):
         plotRef = False
 
       # Determine plot size
-      if plotSize.value is None or plotSize.value is '':
+      if plotSize.value == None or plotSize.value == '':
           plotSizeInternal = '11cm x 4in'
       else:
           plotSizeInternal = plotSize.value
@@ -604,7 +605,7 @@ def script(filename):
     # Loop over requested plots
     for plot in twoDplots.value:
 
-      print '    Writing scripts for 2D plots of quantities ',plot
+      print('    Writing scripts for 2D plots of quantities ',plot)
 
       # Set up filenames
       currentBase = baseFilename+'_'+'_'.join([str(x) for x in plot])
@@ -636,7 +637,7 @@ def script(filename):
         plotRef = False
 
       # Determine plot size
-      if plotSize.value is None or plotSize.value is '':
+      if plotSize.value == None or plotSize.value == '':
         if doColourbar.value is not None and plot in doColourbar.value:
           plotSizeInternal = '12.5cm x 4in'
         else:

--- a/pippi_utils.py
+++ b/pippi_utils.py
@@ -7,6 +7,7 @@
 # Originally developed: March 2012
 #############################################################
 
+from __future__ import print_function
 import sys
 import os.path
 import re
@@ -37,30 +38,30 @@ def castable_to_int(x):
 
 def usage():
   #Print pippi usage information
-  print
-  print 'You must be new here (or have fat fingers).  You can use pippi to'
-  print
-  print '  merge two or more chains:'
-  print '    pippi merge <chain1> <chain2> ... <chainx>'
-  print
-  print '  post-process a chain:'
-  print '    pippi pare <chain> <name_of_python_module> <name_of_function_in_module>'
-  print
-  print '  parse a chain using options in iniFile.pip:'
-  print '    pippi parse iniFile.pip'
-  print
-  print '  write plotting scipts for a chain using options in iniFile.pip:'
-  print '    pippi script iniFile.pip'
-  print
-  print '  run plotting scipts for a chain using options in iniFile.pip:'
-  print '    pippi plot iniFile.pip'
-  print
-  print '  print an hdf5 file\'s computed column indices, using options in iniFile.pip:'
-  print '    pippi probe iniFile.pip'
-  print
-  print '  parse, script and plot in one go:'
-  print '    pippi iniFile.pip'
-  print
+  print()
+  print('You must be new here (or have fat fingers).  You can use pippi to')
+  print()
+  print('  merge two or more chains:')
+  print('    pippi merge <chain1> <chain2> ... <chainx>')
+  print()
+  print('  post-process a chain:')
+  print('    pippi pare <chain> <name_of_python_module> <name_of_function_in_module>')
+  print()
+  print('  parse a chain using options in iniFile.pip:')
+  print('    pippi parse iniFile.pip')
+  print()
+  print('  write plotting scipts for a chain using options in iniFile.pip:')
+  print('    pippi script iniFile.pip')
+  print()
+  print('  run plotting scipts for a chain using options in iniFile.pip:')
+  print('    pippi plot iniFile.pip')
+  print()
+  print('  print an hdf5 file\'s computed column indices, using options in iniFile.pip:')
+  print('    pippi probe iniFile.pip')
+  print()
+  print('  parse, script and plot in one go:')
+  print('    pippi iniFile.pip')
+  print()
 
 def safe_open(filename):
   #Try to open input file
@@ -111,8 +112,8 @@ class dataObject:
       else:
         self.value = self.conversion(string)
     except:
-      print "Failed to convert string:"
-      print string
+      print("Failed to convert string:")
+      print(string)
       sys.exit('Error: invalid data format in field '+self.pipFileKey+'. Quitting...\n')
 
 #Conversion functions for parsing pip file entries


### PR DESCRIPTION
Used [2to3](https://docs.python.org/3/library/2to3.html) to automatically add Python 3 compatibility. Also did a hand pass to catch anything left out by the script. Testing on ```../pippi example_diver.pip``` worked in both Python v2 and Python v3 environments on my WSL Ubuntu 20.04 installation.

Majority of changes are:
* print -> print()
* .iteritems() -> .items()
* filter() -> list(filter())
