### PR TITLE
Patching parsing issues with approval

### DIFF
--- a/Readme
+++ b/Readme
@@ -24,8 +24,8 @@ Installation
 Pippi requires almost no installation.
 
 1. Make sure you have the following already installed:
-   * Either Python v2.7 or later or Python v3
-   * NumPy and SciPy libraries for python (NumPy v0.9.0 or
+   * Either Python v2.7 or later or Python v3.8 or later
+   * NumPy, SciPy, and Packaging libraries for python (NumPy v0.9.0 or
      greater is required for full functionality)
    * ctioga2 v0.8 or later
    * bash

--- a/pippi
+++ b/pippi
@@ -43,11 +43,15 @@ def main(arguments):
       try:
         command(arguments[2:])
       except BaseException as err:
-        print()
-        print('Running pippi failed in '+command.__name__+' operation, due to error:')
-        print(err)
-        print()
-        sys.exit()
+        clean_exit = False
+        if isinstance(err, SystemExit):
+          clean_exit = True if err.code == 0 else clean_exit
+        if not clean_exit:
+          print()
+          print('Running pippi failed in '+command.__name__+' operation, due to error:')
+          print(err)
+          print()
+          sys.exit()
       if not command in [merge, pare]:
         print()
         print('Completed sucessfully.')
@@ -61,11 +65,15 @@ def main(arguments):
           try:
             command(arguments[1:])
           except BaseException as err:
-            print()
-            print('Running pippi failed in '+command.__name__+' operation.')
-            print(err)
-            print()
-            sys.exit()
+            clean_exit = False
+            if isinstance(err, SystemExit):
+              clean_exit = True if err.code == 0 else clean_exit
+            if not clean_exit:
+              print()
+              print('Running pippi failed in '+command.__name__+' operation.')
+              print(err)
+              print()
+              sys.exit()
         print()
         print('Completed sucessfully.')
         print()

--- a/pippi_parse.py
+++ b/pippi_parse.py
@@ -17,8 +17,8 @@ from scipy.special import gammaincinv as deltaLnLike
 from scipy.interpolate import InterpolatedUnivariateSpline as oneDspline
 from scipy.interpolate import RectBivariateSpline as twoDbilinear
 
-from distutils.version import StrictVersion
-if StrictVersion(scipyCurrent.version) >= StrictVersion("0.9.0"):
+from packaging.version import Version
+if Version(scipyCurrent.version) >= Version("0.9.0"):
   from scipy.interpolate import CloughTocher2DInterpolator as twoDspline
 
 # Define parse-specific pip file entries
@@ -69,7 +69,7 @@ def parse(filename):
   if twoDplots.value is not None:
     if intMethod.value is None: intMethod.value = allowedIntMethods[0]
     if intMethod.value not in allowedIntMethods: sys.exit('Error: unrecognised interpolation_method.')
-    if intMethod.value == 'spline' and StrictVersion(scipyCurrent.version) < StrictVersion("0.9.0"):
+    if intMethod.value == 'spline' and Version(scipyCurrent.version) < Version("0.9.0"):
       sys.exit('Sorry, Clough-Tocher 2D interpolation is not supported in SciPy \n'+
                'v0.8 or lower; please upgrade your installation to use this option.')
 

--- a/pippi_read.py
+++ b/pippi_read.py
@@ -278,7 +278,7 @@ def getChainData(filename, cut_all_invalid=None, requested_cols=None, assignment
       for i, column_name in enumerate(column_names):
         if column_name != '': print("   ", i, ":", column_name)
       print()
-      quit()
+      sys.exit(0)
 
     # Identify any likelihood or multiplicity indicated by the labels.
     if labels:

--- a/pippi_read.py
+++ b/pippi_read.py
@@ -313,7 +313,7 @@ def getChainData(filename, cut_all_invalid=None, requested_cols=None, assignment
         data_isvalid.append(np.array(entries[column_names[index]+"_isvalid"], dtype=np.float64))
       lookup_key[index] = index_count
       index_count += 1
-    non_functional_cols = [i for i, elem in enumerate(data) if data[i] != 'functional']
+    non_functional_cols = [i for i, elem in enumerate(data) if np.all(data[i] != 'functional')] # Numpy now requires the user cast to a scalar when performing boolean checks on arrays
     if not non_functional_cols:
       print("ERROR: At least one non-function assignment is needed in")
       print("assign_to_pippi_datastream, or a multiplicity or likelihood")
@@ -325,13 +325,13 @@ def getChainData(filename, cut_all_invalid=None, requested_cols=None, assignment
     # Fill in the functional columns with zeros.  Note that this uses more memory than doing it after validity
     # cuts, but should actually be faster (I think; haven't actually tested that). It makes the code simpler too.
     for i, elem in enumerate(data):
-      if elem == 'functional':
+      if np.any(elem == 'functional'): # Numpy cast to a scalar boolean check
         data[i] = np.zeros(total_samples, dtype=np.float64)
       else:
         # Do some pruning to deal with cases where the some datasets have extra entries (although this arguably indicates a bug in the sampler)
         data[i] = elem[:total_samples]
     for i, elem in enumerate(data_isvalid):
-      if elem == 'functional':
+      if np.any(elem == 'functional'): # Numpy cast to a scalar boolean check
         data_isvalid[i] = np.ones(total_samples, dtype=np.float64)
       else:
         # Do some pruning to deal with cases where the some datasets have extra entries (although this arguably indicates a bug in the sampler)


### PR DESCRIPTION
Patches:

- The change in Numpy [v1.25.0](https://numpy.org/doc/stable/release/1.25.0-notes.html) that depreciated the ambiguity of boolean operations on arrays with other types
- The depreciation of Distutils in [PEP 632](https://peps.python.org/pep-0632/) (Python10 and above)
- Erroneous printing of an empty error message when the try-except block catches a clean early exit in the probe operation

I've cherry-picked the commits on top of the `revert-9-fixes` branch so `master` can be fast forwarded once #10 is merged.